### PR TITLE
Fix: sender_fingerprint default value & payload

### DIFF
--- a/scmail.py
+++ b/scmail.py
@@ -135,17 +135,17 @@ def register(ctx, fingerprint):
 
 @click.command()
 @click.option('--fingerprint', '-f', prompt='Enter fingerprint of mailbox', required=True, help='The fingerprint of the yourself mailbox.')
-@click.option('--sender-fingerprint', '-s', prompt='Enter the fingerprint of sender', default=None, help='The senders fingerprint.')
+@click.option('--sender-fingerprint', '-s', prompt='Enter the fingerprint of sender', default='', help='The senders fingerprint.')
 @click.password_option('--password', '-p', prompt='Enter password of private key', help='The passphrase of private key')
 @click.pass_context
 def retrieve(ctx, fingerprint, sender_fingerprint, password):
     """Retrieve and Post messages from API"""
     logging.debug(fingerprint, sender_fingerprint)
-    data = {'fingerprint': fingerprint}
-    if not sender_fingerprint:
-        data.update(sender_fingerprint, sender_fingerprint)
+    payload = {'fingerprint': fingerprint}
+    if sender_fingerprint:
+        payload.update({'sender_fingerprint': sender_fingerprint})
     # Retrieve
-    r = requests.post(SECUREMAILBOX_URL + '/retrieve/', json=data)
+    r = requests.post(SECUREMAILBOX_URL + '/retrieve/', json=payload)
     res = r.json()
     logging.debug(f'response is: {res}')
 


### PR DESCRIPTION
Regarding the retrieve functionality, these fixes:

1. Allow the user to press [enter] when prompted for the sender's fingerprint, assigning `sender_fingerprint` to a default value of `''` (empty string).

    This looks like the following:
    ```bash
    Enter fingerprint of mailbox: 8908218A320019CC0F37C80630C9054FDFA961B1
    Enter the fingerprint of sender []: 
    Enter password of private key: 
    ```
    Whereas before:
    ```bash
    Enter fingerprint of mailbox: 8908218A320019CC0F37C80630C9054FDFA961B1
    Enter the fingerprint of sender: 
    Enter the fingerprint of sender: 
    Enter the fingerprint of sender: 123senderfingerprint123
    Enter password of private key:
    ```
    pressing [enter] would continue to prompt the user for the sender's fingerprint until one was supplied.

2. Adjust the `payload` so that if a `sender_fingerprint` is supplied, the request will ONLY send back messages from that sender.

    Consider the following:
    message | sender_fingerprint
    --------- | ------------------
    This is a test message | 123alice123
    This is another test message | 456bob456
    Here's a third test message | 789charlie789

    If the user enters '123alice123' as the `sender_fingerprint`, the request sends back the message: 'This is a test message'

    Prior to these changes, the program would always return all messages regardless of `sender_fingerprint`.
